### PR TITLE
Simple interface for turrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 
 # Visual Studio cache directory
 .vs/
+.vsconfig
 
 # Gradle cache directory
 .gradle/

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@
 
 # Visual Studio cache directory
 .vs/
-.vsconfig
 
 # Gradle cache directory
 .gradle/
@@ -75,6 +74,6 @@ crashlytics-build.properties
 # Custom patterns
 #
 .idea/
-
+.vsconfig
 *.blend1
 *.blend1.meta

--- a/Assets/AxeAnimationSyncher.cs
+++ b/Assets/AxeAnimationSyncher.cs
@@ -12,7 +12,7 @@ public class AxeAnimationSyncher : MonoBehaviour
     }
     public void animationTossEvent()
     {
-        controller.toss();
+        controller.Shoot();
     }
     public void animationSpawnEvent()
     {

--- a/Assets/AxeTowerController.cs
+++ b/Assets/AxeTowerController.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class AxeTowerController : Interactable
+public class AxeTowerController : Interactable, TurretInterface
 {
     public MeshRenderer handAxe, totemAxe;
     public Transform spawnPoint;
@@ -45,7 +45,7 @@ public class AxeTowerController : Interactable
         handAxe.enabled = true;
         totemAxe.enabled = false;
     }
-    public void toss()
+    public void Shoot()
     {
         handAxe.enabled = false;
         Rigidbody projectileBody =  Instantiate(axeProjectilePrefab, spawnPoint.position, spawnPoint.rotation).GetComponent<Rigidbody>();

--- a/Assets/Scripts/Towers/LightningShootable.cs
+++ b/Assets/Scripts/Towers/LightningShootable.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class LightningShootable : MonoBehaviour
+public class LightningShootable : MonoBehaviour, TurretInterface
 {
 
     //*********************************************************************************************************

--- a/Assets/Scripts/Towers/TurretInterface.cs
+++ b/Assets/Scripts/Towers/TurretInterface.cs
@@ -2,17 +2,8 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class TurretInterface : MonoBehaviour
+public interface TurretInterface
 {
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
+    //Function to be called in animation controller to make the turret fire.
+    void Shoot();
 }

--- a/Assets/Scripts/Towers/TurretInterface.cs
+++ b/Assets/Scripts/Towers/TurretInterface.cs
@@ -4,6 +4,6 @@ using UnityEngine;
 
 public interface TurretInterface
 {
-    //Function to be called in animation controller to make the turret fire.
+    // Called through animation events on `.anim` files to make the turret fire.
     void Shoot();
 }

--- a/Assets/Scripts/Towers/TurretInterface.cs
+++ b/Assets/Scripts/Towers/TurretInterface.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TurretInterface : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/Towers/TurretInterface.cs.meta
+++ b/Assets/Scripts/Towers/TurretInterface.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 73bd232e092997f4780dcc644c8aaa27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
All turrets should have a common way to be told to shoot. By implementing an interface, calling the shooting function in animation controllers should be more consistent across different turrets.